### PR TITLE
Modern Folder Selector

### DIFF
--- a/FolderPicker.ps1
+++ b/FolderPicker.ps1
@@ -1,0 +1,155 @@
+$folderPickerSource = @'
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Windows.Forms;
+/// <summary>
+/// Present the Windows Vista-style open file dialog to select a folder. Fall back for older Windows Versions
+/// </summary>
+#pragma warning disable 0219, 0414, 0162
+public class FolderSelectDialog {
+    private string _initialDirectory;
+    private string _title;
+    private string _message;
+    private string _fileName = "";
+    
+    public string InitialDirectory {
+        get { return string.IsNullOrEmpty(_initialDirectory) ? Environment.CurrentDirectory : _initialDirectory; }
+        set { _initialDirectory = value; }
+    }
+    public string Title {
+        get { return _title ?? "Select a folder"; }
+        set { _title = value; }
+    }
+    public string Message {
+        get { return _message ?? _title ?? "Select a folder"; }
+        set { _message = value; }
+    }
+    public string FileName { get { return _fileName; } }
+
+    public FolderSelectDialog(string defaultPath="MyComputer", string title="Select a folder", string message=""){
+        InitialDirectory = defaultPath;
+        Title = title;
+        Message = message;
+    }
+    
+    public bool Show() { return Show(IntPtr.Zero); }
+
+    /// <param name="hWndOwner">Handle of the control or window to be the parent of the file dialog</param>
+    /// <returns>true if the user clicks OK</returns>
+    public bool Show(IntPtr? hWndOwnerNullable=null) {
+        IntPtr hWndOwner = IntPtr.Zero;
+        if(hWndOwnerNullable!=null)
+            hWndOwner = (IntPtr)hWndOwnerNullable;
+        if(Environment.OSVersion.Version.Major >= 6){
+            try{
+                var resulta = VistaDialog.Show(hWndOwner, InitialDirectory, Title, Message);
+                _fileName = resulta.FileName;
+                return resulta.Result;
+            }
+            catch(Exception){
+                var resultb = ShowXpDialog(hWndOwner, InitialDirectory, Title, Message);
+                _fileName = resultb.FileName;
+                return resultb.Result;
+            }
+        }
+        var result = ShowXpDialog(hWndOwner, InitialDirectory, Title, Message);
+        _fileName = result.FileName;
+        return result.Result;
+    }
+
+    private struct ShowDialogResult {
+        public bool Result { get; set; }
+        public string FileName { get; set; }
+    }
+
+    private static ShowDialogResult ShowXpDialog(IntPtr ownerHandle, string initialDirectory, string title, string message) {
+        var folderBrowserDialog = new FolderBrowserDialog {
+            Description = message,
+            SelectedPath = initialDirectory,
+            ShowNewFolderButton = true
+        };
+        var dialogResult = new ShowDialogResult();
+        if (folderBrowserDialog.ShowDialog(new WindowWrapper(ownerHandle)) == DialogResult.OK) {
+            dialogResult.Result = true;
+            dialogResult.FileName = folderBrowserDialog.SelectedPath;
+        }
+        return dialogResult;
+    }
+
+    private static class VistaDialog {
+        private const string c_foldersFilter = "Folders|\n";
+        
+        private const BindingFlags c_flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+        private readonly static Assembly s_windowsFormsAssembly = typeof(FileDialog).Assembly;
+        private readonly static Type s_iFileDialogType = s_windowsFormsAssembly.GetType("System.Windows.Forms.FileDialogNative+IFileDialog");
+        private readonly static MethodInfo s_createVistaDialogMethodInfo = typeof(OpenFileDialog).GetMethod("CreateVistaDialog", c_flags);
+        private readonly static MethodInfo s_onBeforeVistaDialogMethodInfo = typeof(OpenFileDialog).GetMethod("OnBeforeVistaDialog", c_flags);
+        private readonly static MethodInfo s_getOptionsMethodInfo = typeof(FileDialog).GetMethod("GetOptions", c_flags);
+        private readonly static MethodInfo s_setOptionsMethodInfo = s_iFileDialogType.GetMethod("SetOptions", c_flags);
+        private readonly static uint s_fosPickFoldersBitFlag = (uint) s_windowsFormsAssembly
+            .GetType("System.Windows.Forms.FileDialogNative+FOS")
+            .GetField("FOS_PICKFOLDERS")
+            .GetValue(null);
+        private readonly static ConstructorInfo s_vistaDialogEventsConstructorInfo = s_windowsFormsAssembly
+            .GetType("System.Windows.Forms.FileDialog+VistaDialogEvents")
+            .GetConstructor(c_flags, null, new[] { typeof(FileDialog) }, null);
+        private readonly static MethodInfo s_adviseMethodInfo = s_iFileDialogType.GetMethod("Advise");
+        private readonly static MethodInfo s_unAdviseMethodInfo = s_iFileDialogType.GetMethod("Unadvise");
+        private readonly static MethodInfo s_showMethodInfo = s_iFileDialogType.GetMethod("Show");
+
+        public static ShowDialogResult Show(IntPtr ownerHandle, string initialDirectory, string title, string description) {
+            var openFileDialog = new OpenFileDialog {
+                AddExtension = false,
+                CheckFileExists = false,
+                DereferenceLinks = true,
+                Filter = c_foldersFilter,
+                InitialDirectory = initialDirectory,
+                Multiselect = false,
+                Title = title
+            };
+
+            var iFileDialog = s_createVistaDialogMethodInfo.Invoke(openFileDialog, new object[] { });
+            s_onBeforeVistaDialogMethodInfo.Invoke(openFileDialog, new[] { iFileDialog });
+            s_setOptionsMethodInfo.Invoke(iFileDialog, new object[] { (uint) s_getOptionsMethodInfo.Invoke(openFileDialog, new object[] { }) | s_fosPickFoldersBitFlag });
+            var adviseParametersWithOutputConnectionToken = new[] { s_vistaDialogEventsConstructorInfo.Invoke(new object[] { openFileDialog }), 0U };
+            s_adviseMethodInfo.Invoke(iFileDialog, adviseParametersWithOutputConnectionToken);
+
+            try {
+                int retVal = (int) s_showMethodInfo.Invoke(iFileDialog, new object[] { ownerHandle });
+                return new ShowDialogResult {
+                    Result = retVal == 0,
+                    FileName = openFileDialog.FileName
+                };
+            }
+            finally {
+                s_unAdviseMethodInfo.Invoke(iFileDialog, new[] { adviseParametersWithOutputConnectionToken[1] });
+            }
+        }
+    }
+
+    // Wrap an IWin32Window around an IntPtr
+    private class WindowWrapper : IWin32Window {
+        private readonly IntPtr _handle;
+        public WindowWrapper(IntPtr handle) { _handle = handle; }
+        public IntPtr Handle { get { return _handle; } }
+    }
+    
+    public string getPath(){
+        if (Show()){
+            return FileName;
+        }
+        return "";
+    }
+}
+'@
+Add-Type -Language CSharp -TypeDefinition $folderPickerSource -ReferencedAssemblies ("System.Windows.Forms", "System.ComponentModel.Primitives")
+
+function Get-Folder {
+	param(
+		[string]$DefaultPath = "C:\",
+		[string]$Title = "Select a Folder",
+		[string]$Message = ""
+	)
+	return ([FolderSelectDialog]::new($DefaultPath, $Title, $Message)).getPath()
+}

--- a/FolderPicker.ps1
+++ b/FolderPicker.ps1
@@ -151,5 +151,8 @@ function Get-Folder {
 		[string]$Title = "Select a Folder",
 		[string]$Message = ""
 	)
-	return ([FolderSelectDialog]::new($DefaultPath, $Title, $Message)).getPath()
+	$dlg = [FolderSelectDialog]::new($DefaultPath, $Title, $Message)
+	$path = $dlg.getPath()
+	if ([string]::IsNullOrWhiteSpace($path)) { return $null }
+	return $path
 }

--- a/FolderPicker.ps1
+++ b/FolderPicker.ps1
@@ -143,7 +143,7 @@ public class FolderSelectDialog {
     }
 }
 '@
-Add-Type -Language CSharp -TypeDefinition $folderPickerSource -ReferencedAssemblies ("System.Windows.Forms", "System.ComponentModel.Primitives")
+Add-Type -Language CSharp -TypeDefinition $folderPickerSource -ReferencedAssemblies ("System.Windows.Forms")
 
 function Get-Folder {
 	param(

--- a/FolderPicker.ps1
+++ b/FolderPicker.ps1
@@ -27,7 +27,7 @@ public class FolderSelectDialog {
     }
     public string FileName { get { return _fileName; } }
 
-    public FolderSelectDialog(string defaultPath="MyComputer", string title="Select a folder", string message=""){
+    public FolderSelectDialog(string defaultPath=Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), string title="Select a folder", string message=""){
         InitialDirectory = defaultPath;
         Title = title;
         Message = message;

--- a/dbdreshade.ps1
+++ b/dbdreshade.ps1
@@ -3,7 +3,13 @@ Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
 
 # Import Get-Folder function from FolderPicker.ps1
-. "$PSScriptRoot\FolderPicker.ps1"
+$folderPicker = Join-Path $PSScriptRoot 'FolderPicker.ps1'  
+if (Test-Path $folderPicker) {  
+    . $folderPicker  
+} else {
+    [System.Windows.Forms.MessageBox]::Show("Missing dependency: FolderPicker.ps1")  
+    return 
+}
 
 # URL of the repository to check releases
 $repoUrl = "https://api.github.com/repos/Joolace/dbd-reshade/releases/latest"
@@ -185,7 +191,7 @@ $button3.Add_Click({
 
     # Event handler for the "Select Destination" button
     $destinationButton.Add_Click({
-        $selectedPath = Get-Folder -DefaultPath "C:\Users" -Title "Select Destination Folder" -Message "Please select a destination folder for the presets." 
+        $selectedPath = Get-Folder -DefaultPath ([Environment]::GetFolderPath('UserProfile')) -Title "Select Destination Folder" -Message "Please select a destination folder for the presets." 
         if ($selectedPath) {
             Set-Variable -Name destinationFolder -Value $selectedPath -Scope Script
             $copyButton.Enabled = $true  # Enable the "Copy" button after selecting a destination
@@ -1044,7 +1050,7 @@ $script:selectedFolder = ""
 
 # Function to open a folder browser dialog and select a folder
 function Select-Folder {
-    $selectedPath = Get-Folder -DefaultPath "C:\Users" -Title "Select Destination Folder" -Message "Please select a destination folder for the presets." 
+    $selectedPath = Get-Folder -DefaultPath ([Environment]::GetFolderPath('UserProfile')) -Title "Select Destination Folder" -Message "Please select a destination folder for the presets." 
     if ($selectedPath) {
         $script:selectedFolder = $selectedPath
         Add-LogEntry "Selected folder: $script:selectedFolder"

--- a/dbdreshade.ps1
+++ b/dbdreshade.ps1
@@ -1,7 +1,9 @@
-
 # Import Windows Forms to create the form and components
 Add-Type -AssemblyName System.Windows.Forms
 Add-Type -AssemblyName System.Drawing
+
+# Import Get-Folder function from FolderPicker.ps1
+. "$PSScriptRoot\FolderPicker.ps1"
 
 # URL of the repository to check releases
 $repoUrl = "https://api.github.com/repos/Joolace/dbd-reshade/releases/latest"
@@ -183,9 +185,9 @@ $button3.Add_Click({
 
     # Event handler for the "Select Destination" button
     $destinationButton.Add_Click({
-        $folderDialog = New-Object System.Windows.Forms.FolderBrowserDialog
-        if ($folderDialog.ShowDialog() -eq "OK") {
-            Set-Variable -Name destinationFolder -Value $folderDialog.SelectedPath -Scope Script
+        $selectedPath = Get-Folder -DefaultPath "C:\Users" -Title "Select Destination Folder" -Message "Please select a destination folder for the presets." 
+        if ($selectedPath) {
+            Set-Variable -Name destinationFolder -Value $selectedPath -Scope Script
             $copyButton.Enabled = $true  # Enable the "Copy" button after selecting a destination
         }
     })
@@ -1042,10 +1044,9 @@ $script:selectedFolder = ""
 
 # Function to open a folder browser dialog and select a folder
 function Select-Folder {
-    $folderBrowser = New-Object System.Windows.Forms.FolderBrowserDialog
-    $folderBrowser.Description = "Select the folder where you want to install the preset."
-    if ($folderBrowser.ShowDialog() -eq 'OK') {
-        $script:selectedFolder = $folderBrowser.SelectedPath
+    $selectedPath = Get-Folder -DefaultPath "C:\Users" -Title "Select Destination Folder" -Message "Please select a destination folder for the presets." 
+    if ($selectedPath) {
+        $script:selectedFolder = $selectedPath
         Add-LogEntry "Selected folder: $script:selectedFolder"
         Show-MessageBox "Selected folder: $script:selectedFolder"
     }


### PR DESCRIPTION
This pull request aims to update the folder selector for the "Copy All Presets" to use the modern windows 10/11 file explorer.

I took [this selected answer](https://stackoverflow.com/a/66823582/18673230) from the stack overflow question [Use the upgraded FolderBrowserDialog ("Vista style") in Powershell](https://stackoverflow.com/questions/66823581/use-the-upgraded-folderbrowserdialog-vista-style-in-powershell), craeted a Get-Folder function, and threw those into FolderPicker.ps1

I then imported it into dbdreshade.ps1 and in both spots using

```powershell
System.Windows.Forms.FolderBrowserDialog
```

I changed it to use 

```powershell
# import
. "$PSScriptRoot\FolderPicker.ps1

# actual usage
$selectedPath = Get-Folder -DefaultPath "C:\Users" -Title "Select Destination Folder" -Message "Please select a destination folder for the presets."
```

Locally, everything seems to be working, but feel free to test it out and verify that it works! I'd love to see this quality of life update!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new folder selection dialog with an updated Windows Vista-style interface, with fallback support for older Windows versions.
  - Added a PowerShell function to select folders with customizable default path, title, and message.

- **Refactor**
  - Updated folder selection in related scripts to use the new centralized folder picker function, ensuring a consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->